### PR TITLE
PROBLEM: Build is failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
         packages:
         - valgrind
         - liblua5.1-0-dev
+        - asciidoc
+        - xmlto
 
 addons:
   apt:


### PR DESCRIPTION
[   83s] dpkg-checkbuilddeps: Unmet build dependencies: dh-systemd
asciidoc-base | asciidoc xmlto dh-autoreconf
[   83s] dpkg-buildpackage: warning: build dependencies/conflicts
iunsatisfied; aborting

SOLUTION: Add unmet dependencies.

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>