### PR TITLE
PROBLEM: Old service name used

### DIFF
--- a/src/fty_metric_composite_configurator_server.cc
+++ b/src/fty_metric_composite_configurator_server.cc
@@ -82,7 +82,7 @@ s_remove_and_stop (const char *path_to_dir)
         if (std::regex_match (zfile_filename (item, path_to_dir), file_rex)) {
             std::string filename = zfile_filename (item, path_to_dir);
             filename.erase (filename.size () - 4);
-            std::string service = "composite-metrics@";
+            std::string service = "fty-metric-composite@";
             service += filename;
             s_bits_systemctl ("stop", service.c_str ());
             s_bits_systemctl ("disable", service.c_str ());
@@ -239,7 +239,7 @@ s_generate_and_start (const char *path_to_dir, const char *sensor_function, cons
     fullpath += filename;
     fullpath += ".cfg";
 
-    std::string service = "composite-metrics";
+    std::string service = "fty-metric-composite";
     service += "@";
     service += filename;
 
@@ -282,7 +282,7 @@ s_generate_and_start (const char *path_to_dir, const char *sensor_function, cons
     fullpath += filename;
     fullpath += ".cfg";
 
-    service = "composite-metrics";
+    service = "fty-metric-composite";
     service += "@";
     service += filename;
 


### PR DESCRIPTION
BIOS-3224: No environment data in UI
fty-metric-composite-configurator is trying to enable/start
'composite-metrics@...' which is the old name for fty-metric-composite

SOLUTION: Fix it!

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>