### PR TITLE
Problem: c_metric_conf_set_cfgdir() did not check for R/W access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ CMakeLists.txt
 builds/cmake/
 
 # Repositories downloaded by CI integration scripts
+libsodium/
 libzmq/
 czmq/
 malamute/

--- a/src/actor_commands.cc
+++ b/src/actor_commands.cc
@@ -436,7 +436,7 @@ actor_commands_test (bool verbose)
     assert (streq (c_metric_conf_statefile (cfg), test_state_file));
     assert (streq (c_metric_conf_cfgdir (cfg), ""));
 
-    // CFG_DIRECTORY
+    // CFG_DIRECTORY, expected writable (current builddir of course is, right?)
     message = zmsg_new ();
     assert (message);
     zmsg_addstr (message, "CFG_DIRECTORY");
@@ -447,16 +447,19 @@ actor_commands_test (bool verbose)
     assert (streq (c_metric_conf_statefile (cfg), test_state_file));
     assert (streq (c_metric_conf_cfgdir (cfg), "./"));
 
-    // CFG_DIRECTORY
+    // CFG_DIRECTORY, expected writable
+    // Note: the (originally non-absolute) config path is still stored
+    // relative to process CWD at least currently, not sure this is a
+    // good thing - but it is expected according to original tests.
     message = zmsg_new ();
     assert (message);
     zmsg_addstr (message, "CFG_DIRECTORY");
-    zmsg_addstr (message, "../");
+    zmsg_addstr (message, SELFTEST_DIR_RW);
     rv = actor_commands (cfg, &data, &message);
     assert (rv == 0);
     assert (message == NULL);
     assert (streq (c_metric_conf_statefile (cfg), test_state_file));
-    assert (streq (c_metric_conf_cfgdir (cfg), "../"));
+    assert (streq (c_metric_conf_cfgdir (cfg), SELFTEST_DIR_RW));
 
     zmsg_destroy (&message);
     c_metric_conf_destroy (&cfg);

--- a/src/actor_commands.cc
+++ b/src/actor_commands.cc
@@ -464,6 +464,7 @@ actor_commands_test (bool verbose)
     zmsg_destroy (&message);
     c_metric_conf_destroy (&cfg);
     data_destroy (&data);
+    zsys_file_delete (test_state_file);
     zstr_free (&test_state_file);
     zactor_destroy (&malamute);
     //  @end

--- a/src/c_metric_conf.cc
+++ b/src/c_metric_conf.cc
@@ -285,6 +285,8 @@ c_metric_conf_test (bool verbose)
     const char *state_file = c_metric_conf_statefile (self);
     assert (streq (state_file, ""));
     char *test_state_file = NULL;
+    char *test_state_dir = zsys_sprintf ("%s/test_dir", SELFTEST_DIR_RW);
+    assert (test_state_dir != NULL);
 
     test_state_file = zsys_sprintf ("%s/state_file", SELFTEST_DIR_RW);
     assert (test_state_file != NULL);
@@ -294,17 +296,22 @@ c_metric_conf_test (bool verbose)
     assert (streq (state_file, test_state_file));
     zstr_free (&test_state_file);
 
-    rv = c_metric_conf_set_statefile (self, "/tmp/composite-metrics/state_file");
+    test_state_file = (char *)"/tmp/composite-metrics/state_file";
+    rv = c_metric_conf_set_statefile (self, test_state_file);
     assert (rv == 0);
     state_file = c_metric_conf_statefile (self);
-    assert (streq (state_file, "/tmp/composite-metrics/state_file"));
+    assert (streq (state_file, test_state_file));
 
-    test_state_file = zsys_sprintf ("%s/test_dir/state_file", SELFTEST_DIR_RW);
+    // Make sure we can create a directory to hold the statefile, if asked to
+    zsys_dir_delete (test_state_dir);
+    test_state_file = zsys_sprintf ("%s/state_file", test_state_dir);
     assert (test_state_file != NULL);
     rv = c_metric_conf_set_statefile (self, test_state_file);
     assert (rv == 0);
     state_file = c_metric_conf_statefile (self);
     assert (streq (state_file, test_state_file));
+    zsys_file_delete (test_state_file);
+    zsys_dir_delete (test_state_dir);
 
     // directory (assumed to exist); state_file value should remain the same
     rv = c_metric_conf_set_statefile (self, "/lib");
@@ -337,6 +344,9 @@ c_metric_conf_test (bool verbose)
         assert (streq (cfgdir, "/tmp"));
     } // if root
     } // scope
+
+    zsys_dir_delete (test_state_dir);
+    zstr_free (&test_state_dir);
 
     c_metric_conf_destroy (&self);
     //  @end

--- a/src/data.cc
+++ b/src/data.cc
@@ -993,6 +993,8 @@ test4 (bool verbose)
     data_destroy (&self);
     data_destroy (&self_load);
     data_destroy (&self_load_load);
+    zsys_file_delete (test_state_file);
+    zsys_file_delete (test_state_file1);
     zstr_free (&test_state_file);
     zstr_free (&test_state_file1);
 }

--- a/src/fty_metric_composite_configurator_server.cc
+++ b/src/fty_metric_composite_configurator_server.cc
@@ -1071,6 +1071,16 @@ retry_block_1:
         }
 
         assert (rv == 0);
+
+        // Cleanup after the test bit
+        for (std::string &it : expected_configs) {
+            char *expected_filename = zsys_sprintf ("%s/%s", test_state_dir, it.c_str());
+            assert (expected_filename != NULL);
+            if (verbose) printf("TRACE BLOCK-1 zsys_file_delete('%s')", expected_filename);
+            zsys_file_delete (expected_filename);
+            zstr_free (&expected_filename);
+        }
+
         printf ("Test block -1- Ok\n");
     }
 
@@ -1369,6 +1379,14 @@ retry_block_1:
             zmsg_destroy (&message);
         }
 
+        // Cleanup after the test bit
+        for (std::string &it : expected_configs) {
+            char *expected_filename = zsys_sprintf ("%s/%s", test_state_dir, it.c_str());
+            assert (expected_filename != NULL);
+            if (verbose) printf("TRACE BLOCK-2 zsys_file_delete('%s')", expected_filename);
+            zsys_file_delete (expected_filename);
+            zstr_free (&expected_filename);
+        }
 
         zlistx_destroy (&expected_unavailable);
 
@@ -1470,17 +1488,37 @@ retry_block_1:
             zstr_free (&part);
             zmsg_destroy (&message);
         }
+
+        // Cleanup after the test bit
+        for (std::string &it : expected_configs) {
+            char *expected_filename = zsys_sprintf ("%s/%s", test_state_dir, it.c_str());
+            assert (expected_filename != NULL);
+            if (verbose) printf("TRACE BLOCK-3 zsys_file_delete('%s')", expected_filename);
+            zsys_file_delete (expected_filename);
+            zstr_free (&expected_filename);
+        }
+
         zlistx_destroy (&expected_unavailable);
 
         printf ("Test block -3- Ok\n");
     }*/
 
-    zstr_free (&test_state_file);
-    zstr_free (&test_state_dir);
     mlm_client_destroy (&producer);
     mlm_client_destroy (&alert_generator);
     zactor_destroy (&configurator);
     zactor_destroy (&server);
+
+    // Ideally, nothing should be here by now...
+    dir = zdir_new (test_state_dir, NULL);
+    if (dir) {
+        zdir_remove (dir, true);
+        zdir_destroy (&dir);
+    }
+
+    zsys_file_delete (test_state_file);
+    zsys_dir_delete  (test_state_dir);
+    zstr_free (&test_state_file);
+    zstr_free (&test_state_dir);
     //  @end
     printf ("OK\n");
 }


### PR DESCRIPTION
Solution: tests require that the config dir exists and is writable,
but the code only enforced the former requirement. Depending
on the test env (absence/presence/visibility of tested directory)
the selftest might succeed but not really reliable.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>